### PR TITLE
showterm -e  to edit timings file afterward.

### DIFF
--- a/bin/showterm
+++ b/bin/showterm
@@ -3,32 +3,81 @@
 require 'readline'
 require File.join(File.dirname(File.dirname(__FILE__)), 'lib/showterm')
 
+if '-e' == ARGV[0]
+  $edit_timings = true
+  ARGV.shift
+end
+
 if ARGV.include?('-h') || ARGV.include?('--help')
   puts <<-EOF
-Usage: showterm <command to run>
+Usage: showterm [-e] <command to run>
 
 showterm will record the exact output of your session, and upload it to the
 internet where it can be replayed by anyone to whom you give the URL.
+
+You can pass `-e` as the first arg and it will allow you to edit the timings
+file before uploading. This can be nice if you want to take long pauses (such
+as searching an answer out) in between commands.
  EOF
  exit
 end
 
-sf, tf = Showterm.record! *ARGV
-begin
-  Showterm.upload! sf, tf
-rescue => e
-  File.open("/tmp/showtime.#$$.script", 'w') do |f|
-    f.write(sf)
+def save which, data
+  path = "/tmp/showtime.#$$.#{which}"
+  File.open(path, 'w') do |f|
+    f.write(data)
   end
+  path
+end
 
-  File.open("/tmp/showtime.#$$.times", 'w') do |f|
-    f.write(sf)
+def leave_trace message, sf, tf
+  script_path = save 'script', sf
+  times_path = save 'times', tf
+  puts message
+  puts %(your work is safe in "#{script_path}" and "#{times_path}")
+  puts "To try uploading manually, use:"
+  puts %(ruby -rshowterm -e'Showterm.upload! File.read("/tmp/showtime.#$$.script"), File.read("/tmp/showtime.#$$.times")')
+end
+
+puts 'showterm recording. (Exit shell when done.)'
+sf, tf = Showterm.record! *ARGV
+puts 'showterm recording finished.'
+
+if $edit_timings
+  editor = ENV.fetch('VISUAL', ENV.fetch('EDITOR', 'vim'))
+  tips = if 'vim' == editor
+    <<-TIPS
+Hot vim tips:
+  Use :cq  from vim to exit nonzero, and cancel the upload
+  Use :%s/^[0-9]\./0./  to get rid of all longish pauses.
+    TIPS
+  else
+    <<-CONSOLATION_TIPS
+If you can make your editor return nonzero, it will cancel the upload.
+    CONSOLATION_TIPS
   end
+  puts <<-TEXT
+
+Recording done, now it's time to dress up those timings!
+#{tips}
+[Hit Enter to edit]
+  TEXT
+  $stdin.readline
+  times_path = save 'times', tf
+  success = system(editor, times_path)
+  if success
+    tf = File.read(times_path)
+  else
+    leave_trace "OK, discarding edits and skipping upload.", sf, tf
+    exit 1
+  end
+end
+
+begin
+  puts "Uploading..."
+  puts Showterm.upload! sf, tf
+rescue => e
   puts [e] + e.backtrace
   puts "-" * 80
-  puts "DON'T PANIC"
-  puts %(your work is safe in "/tmp/showtime.#$$.script" and "/tmp/showtime.#$$.times")
-  puts "To try uploading manually use:"
-
-  puts %(ruby -rshowterm -e'Showterm.upload! File.read("/tmp/showtime.#$$.script"), File.read("/tmp/showtime.#$$.times")')
+  leave_trace "DON'T PANIC", sf, tf
 end

--- a/lib/showterm.rb
+++ b/lib/showterm.rb
@@ -13,14 +13,11 @@ module Showterm
   # @param [*String] cmd
   # @return [scriptfile, timingfile]  the two halves of a termshow
   def record!(*cmd)
-    puts 'showterm recording. (Exit when done.)'
     ret = if use_script?
       record_with_script(*cmd)
     else
       record_with_ttyrec(*cmd)
     end
-    puts 'showterm recording finished, uploading...'
-
     ret
   end
 
@@ -45,7 +42,7 @@ module Showterm
 
     response = http(request)
     raise response.body unless Net::HTTPSuccess === response
-    puts response.body
+    response.body
   rescue => e
     raise if retried
     retried = true

--- a/showterm.gemspec
+++ b/showterm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "showterm"
-  s.version = "0.2.5"
+  s.version = "0.2.6"
   s.platform = Gem::Platform::RUBY
   s.author = "Conrad Irwin"
   s.email = "conrad.irwin@gmail.com"


### PR DESCRIPTION
Personally, I think I'll alias this.

It's nice as a way to bypass upload. Just `:cq` and it dies.
