### PR TITLE
Fix retry mechanism for uploading scripts

### DIFF
--- a/lib/showterm.rb
+++ b/lib/showterm.rb
@@ -35,6 +35,7 @@ module Showterm
   # @param [String] timingfile  The timings
   # @param [Integer] cols  The width of the terminal
   def upload!(scriptfile, timingfile, cols=terminal_width)
+    retried ||= false
     request = Net::HTTP::Post.new("/scripts")
     request.set_form_data(:scriptfile => scriptfile,
                           :timingfile => timingfile,


### PR DESCRIPTION
Showterm client fails to retry after a failed upload crashing because the `retried` variable is not defined. This branch fixes that issue.
